### PR TITLE
feat: Pinch Zoom

### DIFF
--- a/src/components/ReactPhotoEditor.tsx
+++ b/src/components/ReactPhotoEditor.tsx
@@ -201,6 +201,7 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
                       height: canvasHeight ?? 'auto',
                       maxHeight: maxCanvasHeight ?? '22rem',
                       maxWidth: maxCanvasWidth ?? '36rem',
+                      touchAction: 'none',
                     }}
                     className={`rpe-canvas rpe-touch-none rpe-border dark:rpe-border-gray-700 rpe-object-fill rpe-mx-auto 
 											${

--- a/src/components/ReactPhotoEditor.tsx
+++ b/src/components/ReactPhotoEditor.tsx
@@ -50,11 +50,9 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
     grayscale,
     setGrayscale,
     rotate,
-    setRotate,
-    flipHorizontal,
-    setFlipHorizontal,
-    flipVertical,
-    setFlipVertical,
+    handleRotate,
+    handleFlipHorizontal,
+    handleFlipVertical,
     mode,
     setMode,
     setLineColor,
@@ -78,7 +76,7 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
   }, [open]);
   const handleInputChange = (
     event: ChangeEvent<HTMLInputElement>,
-    setValue: React.Dispatch<React.SetStateAction<number>>,
+    setValue: React.Dispatch<React.SetStateAction<number>> | ((value: number) => void),
     min: number,
     max: number
   ) => {
@@ -92,7 +90,7 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
     {
       name: labels.rotate,
       value: rotate,
-      setValue: setRotate,
+      setValue: handleRotate,
       min: -180,
       max: 180,
       type: 'range',
@@ -302,7 +300,7 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
                         <div className='rpe-inline-block' data-testid='flip-btns'>
                           <button
                             className='rpe-mx-1 focus:rpe-ring-2 focus:rpe-ring-gray-300 dark:focus:rpe-ring-gray-700 rpe-rounded-md rpe-p-1'
-                            onClick={() => setFlipHorizontal(!flipHorizontal)}
+                            onClick={() => handleFlipHorizontal()}
                             type='button'
                             title={labels.flipHorizontal}
                             aria-label={labels.flipHorizontal}
@@ -329,7 +327,7 @@ export const ReactPhotoEditor: React.FC<ReactPhotoEditorProps> = ({
                           </button>
                           <button
                             className='rpe-mx-1 focus:rpe-ring-2 focus:rpe-ring-gray-300 dark:focus:rpe-ring-gray-700 rpe-rounded-md rpe-p-1'
-                            onClick={() => setFlipVertical(!flipVertical)}
+                            onClick={() => handleFlipVertical()}
                             type='button'
                             title={labels.flipVertical}
                             aria-label={labels.flipVertical}

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -149,16 +149,6 @@ export const usePhotoEditor = ({
       // Redraw image and drawing paths with current transformations
       context.drawImage(imgRef.current, 0, 0);
       redrawDrawingPaths();
-
-      context.beginPath();
-      context.fillStyle = '#00ff00';
-      context.arc(0,0,10,0,2*Math.PI);
-      context.fill();
-
-      context.beginPath();
-      context.fillStyle = '#ff0000';
-      context.arc(canvasRef.current.width / 2,canvasRef.current.height / 2,10,0,2*Math.PI);
-      context.fill();
     }
   }, [imageSrc]);
 

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -557,6 +557,7 @@ export const usePhotoEditor = ({
     context.translate(centerX, centerY);
     context.rotate((diff * Math.PI) / 180);
     context.translate(-centerX, -centerY);
+    reDraw()
   };
 
   /**

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -616,6 +616,7 @@ export const usePhotoEditor = ({
     const context = canvasRef.current?.getContext('2d');
     context?.resetTransform();
     currentOrigin.current = { x: 0, y: 0 };
+    canvasInitialized.current = false;
     reDraw();
   };
 

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -503,11 +503,14 @@ export const usePhotoEditor = ({
     const centerX = (canvasRef.current?.width ?? 0) / 2;
     const centerY = (canvasRef.current?.height ?? 0) / 2;
 
+    // Reset rotation
     context.translate(centerX, centerY);
     context.rotate(-angle)
     context.translate(-centerX, -centerY);
+    // Apply horizontal flip
     context.translate(canvasRef.current?.width ?? 0, 0);
     context.scale(-1, 1);
+    // Rotate back
     context.translate(centerX, centerY);
     context.rotate(angle)
     context.translate(-centerX, -centerY);
@@ -527,11 +530,14 @@ export const usePhotoEditor = ({
     const centerX = (canvasRef.current?.width ?? 0) / 2;
     const centerY = (canvasRef.current?.height ?? 0) / 2;
 
+    // Reset rotation
     context.translate(centerX, centerY);
     context.rotate(-angle)
     context.translate(-centerX, -centerY);
+    // Apply vertical flip
     context.translate(0, canvasRef.current?.height ?? 0);
     context.scale(1, -1);
+    // Rotate back
     context.translate(centerX, centerY);
     context.rotate(angle)
     context.translate(-centerX, -centerY);

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 /**
  * Parameters for the usePhotoEditor hook.
@@ -8,6 +8,11 @@ interface UsePhotoEditorParams {
    * The image file to be edited.
    */
   file?: File;
+
+  /**
+   * Source URL of the image to be edited.
+   */
+  src?: string;
 
   /**
    * Initial brightness level (default: 100).
@@ -73,6 +78,7 @@ interface UsePhotoEditorParams {
  */
 export const usePhotoEditor = ({
   file,
+  src,
   defaultBrightness = 100,
   defaultContrast = 100,
   defaultSaturate = 100,
@@ -87,6 +93,7 @@ export const usePhotoEditor = ({
 }: UsePhotoEditorParams) => {
   // Ref to the canvas element where the image will be drawn.
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const contextRef = useRef<CanvasRenderingContext2D | null>(null);
 
   // Create the image object using a ref
   const imgRef = useRef(new Image());
@@ -106,7 +113,7 @@ export const usePhotoEditor = ({
 
   // State variables for handling drag-and-drop panning.
   const [isDragging, setIsDragging] = useState(false);
-  const [panStart, setPanStart] = useState<{ x: number; y: number } | null>(null);
+  const prevPanPosition = useRef<{ x: number; y: number } | null>(null);
   const [offsetX, setOffsetX] = useState(0);
   const [offsetY, setOffsetY] = useState(0);
 
@@ -120,19 +127,44 @@ export const usePhotoEditor = ({
   const drawingPathsRef = useRef<
     { path: { x: number; y: number }[]; color: string; width: number }[]
   >([]);
+  const pointerEvents = useRef<Array<React.PointerEvent<HTMLCanvasElement>>>([]);
+  const prevPointerDiff = useRef(-1);
+
+  const reDraw = useCallback(() => {
+    if (imageSrc && canvasRef.current != null) {
+      if (contextRef.current == null) {
+        // Todo: still need to use image onload
+        // Initial setup
+        contextRef.current = canvasRef.current.getContext('2d');
+        // Set canvas dimensions to match the image.
+        canvasRef.current.width = imgRef.current.width;
+        canvasRef.current.height = imgRef.current.height;
+      }
+
+      contextRef.current?.save()
+      contextRef.current?.setTransform(1, 0, 0, 1, 0, 0);
+      contextRef.current?.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+      contextRef.current?.drawImage(imgRef.current, 0, 0);
+      contextRef.current?.restore()
+    }
+  }, [imageSrc]);
 
   // Effect to update the image source when the file changes.
   useEffect(() => {
     if (file) {
       const fileSrc = URL.createObjectURL(file);
+      imgRef.current.src = fileSrc;
       setImageSrc(fileSrc);
 
       // Clean up the object URL when the component unmounts or file changes.
       return () => {
         URL.revokeObjectURL(fileSrc);
       };
+    } else if (src) {
+      imgRef.current.src = src;
+      setImageSrc(src);
     }
-  }, [file]);
+  }, [file, src]);
 
   // Effect to apply transformations and filters whenever relevant state changes.
   useEffect(() => {
@@ -175,59 +207,60 @@ export const usePhotoEditor = ({
    * Applies the selected filters and transformations to the image on the canvas.
    */
   const applyFilter = () => {
-    if (!imageSrc) return;
-
-    const canvas = canvasRef.current;
-    const context = canvas?.getContext('2d');
-
-    const imgElement = imgRef.current;
-    imgRef.current.src = imageSrc;
-    imgRef.current.onload = applyFilter;
-
-    imgElement.onload = () => {
-      if (canvas && context) {
-        const zoomedWidth = imgElement.width * zoom;
-        const zoomedHeight = imgElement.height * zoom;
-        const translateX = (imgElement.width - zoomedWidth) / 2;
-        const translateY = (imgElement.height - zoomedHeight) / 2;
-
-        // Set canvas dimensions to match the image.
-        canvas.width = imgElement.width;
-        canvas.height = imgElement.height;
-
-        // Clear the canvas before drawing the updated image.
-        context.clearRect(0, 0, canvas.width, canvas.height);
-
-        // Apply filters and transformations.
-        context.filter = getFilterString();
-        context.save();
-
-        if (rotate) {
-          const centerX = canvas.width / 2;
-          const centerY = canvas.height / 2;
-          context.translate(centerX, centerY);
-          context.rotate((rotate * Math.PI) / 180);
-          context.translate(-centerX, -centerY);
-        }
-        if (flipHorizontal) {
-          context.translate(canvas.width, 0);
-          context.scale(-1, 1);
-        }
-        if (flipVertical) {
-          context.translate(0, canvas.height);
-          context.scale(1, -1);
-        }
-
-        context.translate(translateX + offsetX, translateY + offsetY);
-        context.scale(zoom, zoom);
-        context.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
-
-        context.restore();
-
-        context.filter = 'none';
-        redrawDrawingPaths(context);
-      }
-    };
+    // if (!imageSrc) return;
+    //
+    //
+    // const canvas = canvasRef.current;
+    // const context = canvas?.getContext('2d');
+    //
+    // const imgElement = imgRef.current;
+    // imgRef.current.src = imageSrc;
+    // imgRef.current.onload = applyFilter;
+    //
+    // imgElement.onload = () => {
+    //   if (canvas && context) {
+    //     // const zoomedWidth = imgElement.width * zoom;
+    //     // const zoomedHeight = imgElement.height * zoom;
+    //     // const translateX = (imgElement.width - zoomedWidth) / 2;
+    //     // const translateY = (imgElement.height - zoomedHeight) / 2;
+    //
+    //     // Set canvas dimensions to match the image.
+    //     canvas.width = imgElement.width;
+    //     canvas.height = imgElement.height;
+    //
+    //     // Clear the canvas before drawing the updated image.
+    //     context.clearRect(0, 0, canvas.width, canvas.height);
+    //
+    //     // Apply filters and transformations.
+    //     context.filter = getFilterString();
+    //     context.save();
+    //
+    //     if (rotate) {
+    //       const centerX = canvas.width / 2;
+    //       const centerY = canvas.height / 2;
+    //       context.translate(centerX, centerY);
+    //       context.rotate((rotate * Math.PI) / 180);
+    //       context.translate(-centerX, -centerY);
+    //     }
+    //     if (flipHorizontal) {
+    //       context.translate(canvas.width, 0);
+    //       context.scale(-1, 1);
+    //     }
+    //     if (flipVertical) {
+    //       context.translate(0, canvas.height);
+    //       context.scale(1, -1);
+    //     }
+    //
+    //     // context.translate(translateX + offsetX, translateY + offsetY);
+    //     // context.scale(zoom, zoom);
+    //     context.drawImage(imgElement, 0, 0);
+    //
+    //     context.restore();
+    //
+    //     context.filter = 'none';
+    //     // redrawDrawingPaths(context);
+    //   }
+    // };
   };
 
   /**
@@ -289,21 +322,24 @@ export const usePhotoEditor = ({
   /**
    * Handles the zoom-in action.
    */
-  const handleZoomIn = () => {
-    setZoom((prevZoom) => prevZoom + 0.1);
+  const handleZoomIn = (value?: number) => {
+    setZoom((prevZoom) => prevZoom + (value ?? 0.1));
   };
 
   /**
    * Handles the zoom-out action.
    */
-  const handleZoomOut = () => {
-    setZoom((prevZoom) => Math.max(prevZoom - 0.1, 0.1));
+  const handleZoomOut = (value?: number) => {
+    setZoom((prevZoom) => Math.max(prevZoom - (value ?? 0.1), 0.1));
   };
 
   /**
    * Handles the pointer down event for initiating drawing or drag-and-drop panning.
    */
   const handlePointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    // Store the pointer event for later use with multiple pointers
+    pointerEvents.current.push(event);
+
     if (mode === 'draw') {
       const canvas = canvasRef.current;
       if (!canvas) return;
@@ -320,7 +356,7 @@ export const usePhotoEditor = ({
       setIsDragging(true);
       const initialX = event.clientX - (flipHorizontal ? -offsetX : offsetX);
       const initialY = event.clientY - (flipVertical ? -offsetY : offsetY);
-      setPanStart({ x: initialX, y: initialY });
+      prevPanPosition.current = { x: initialX, y: initialY };
     }
   };
 
@@ -328,7 +364,30 @@ export const usePhotoEditor = ({
    * Handles the pointer move event for updating the drawing path or panning the image.
    */
   const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    // Find this event in the cache and update its record with this event
+    const index = pointerEvents.current.findIndex(
+      (cachedEv) => cachedEv.pointerId === event.pointerId
+    );
+    pointerEvents.current[index] = event;
+    const rect = canvasRef.current?.getBoundingClientRect();
+
+    console.log(
+      event.clientX,
+      event.clientY,
+      canvasRef.current?.offsetLeft,
+      canvasRef.current?.offsetTop,
+      rect?.left,
+      rect?.top,
+    );
+    console.log(
+      event.clientX - (canvasRef.current?.offsetLeft ?? 0),
+      event.clientY - (canvasRef.current?.offsetTop ?? 0),
+      event.clientX - (rect?.left ?? 0),
+      event.clientY - (rect?.top ?? 0),
+    );
+
     if (mode === 'draw' && drawStart) {
+      // Draw
       const canvas = canvasRef.current;
       const context = canvas?.getContext('2d');
       const rect = canvas?.getBoundingClientRect();
@@ -357,21 +416,80 @@ export const usePhotoEditor = ({
       return;
     }
 
-    if (isDragging && panStart) {
+    if (isDragging && prevPanPosition) {
       event.preventDefault();
 
-      const offsetXDelta = event.clientX - panStart.x;
-      const offsetYDelta = event.clientY - panStart.y;
+      if (pointerEvents.current.length === 1 && prevPanPosition.current != null) {
+        // Pan
+        const offsetXDelta = event.clientX - prevPanPosition.current.x;
+        const offsetYDelta = event.clientY - prevPanPosition.current.y;
 
-      setOffsetX(flipHorizontal ? -offsetXDelta : offsetXDelta);
-      setOffsetY(flipVertical ? -offsetYDelta : offsetYDelta);
+        console.log(`Panning: ${offsetXDelta}, ${offsetYDelta}, context: ${!!contextRef.current}`);
+        contextRef.current?.translate(offsetXDelta, offsetYDelta);
+        reDraw();
+        prevPanPosition.current = {x: event.clientX, y: event.clientY};
+      } else if (pointerEvents.current.length === 2) {
+        const rect = canvasRef.current?.getBoundingClientRect();
+
+        // Pinch Zoom
+        // If two pointers are down, check for pinch gestures
+        // Calculate the distance between the two pointers
+        const curDiff = Math.max(
+          Math.abs(pointerEvents.current[0].clientX - pointerEvents.current[1].clientX),
+          Math.abs(pointerEvents.current[0].clientY - pointerEvents.current[1].clientY)
+        );
+        const zoomOrigin = {
+          x: ((pointerEvents.current[0].clientX - (rect?.left ?? 0)) + (pointerEvents.current[1].clientX - (rect?.left ?? 0))) / 2,
+          y: ((pointerEvents.current[0].clientY - (rect?.top ?? 0)) + (pointerEvents.current[1].clientY - (rect?.top ?? 0))) / 2,
+        };
+
+        if (prevPointerDiff.current > 0) {
+          let zoom = 1;
+          if (curDiff > prevPointerDiff.current) {
+            // The distance between the two pointers has increased
+            // handleZoomIn(Math.abs(prevPointerDiff.current - curDiff) * 0.01);
+            zoom = Math.abs(prevPointerDiff.current - curDiff) * 0.01;
+          }
+          if (curDiff < prevPointerDiff.current) {
+            // The distance between the two pointers has decreased
+            // handleZoomOut(Math.abs(prevPointerDiff.current - curDiff) * 0.01);
+            zoom = Math.abs(prevPointerDiff.current - curDiff) * 0.01;
+          }
+
+          // const originX = imgRef.current.width * zoom / 2;
+          // const originY = imgRef.current.height * zoom / 2;
+
+          // setOffsetX(originX - zoomOrigin.x);
+          // setOffsetY(originY - zoomOrigin.y);
+
+          const context = canvasRef.current?.getContext('2d');
+          if (context) {
+            context.translate(zoomOrigin.x, zoomOrigin.y);
+            context.scale(zoom, zoom);
+            context.translate(-zoomOrigin.x, -zoomOrigin.y);
+          }
+        }
+
+        // Cache the distance for the next move event
+        prevPointerDiff.current = curDiff;
+      }
     }
   };
 
   /**
    * Handles the pointer up event for ending the drawing or panning action.
    */
-  const handlePointerUp = () => {
+  const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    // Remove the pointer event from the array
+    pointerEvents.current = pointerEvents.current.filter(
+      (event) => event.pointerId !== e.pointerId
+    );
+
+    // If the number of pointers down is less than two then reset diff tracker
+    if (pointerEvents.current.length < 2) {
+      prevPointerDiff.current = -1;
+    }
+
     setIsDragging(false);
     setDrawStart(null);
   };
@@ -404,10 +522,11 @@ export const usePhotoEditor = ({
     drawingPathsRef.current = [];
     setOffsetX(0);
     setOffsetY(0);
-    setPanStart(null);
+    prevPanPosition.current = null;
     setIsDragging(false);
     setMode('pan');
-    applyFilter();
+    // applyFilter();
+    reDraw()
   };
 
   // Expose the necessary state and handlers for external use.
@@ -435,7 +554,7 @@ export const usePhotoEditor = ({
     /** Flag indicating if the image is being dragged. */
     isDragging,
     /** Starting coordinates for panning. */
-    panStart,
+    panStart: prevPanPosition,
     /** Current horizontal offset for panning. */
     offsetX,
     /** Current vertical offset for panning. */
@@ -464,8 +583,6 @@ export const usePhotoEditor = ({
     setZoom,
     /** Function to set the dragging state. */
     setIsDragging,
-    /** Function to set the starting coordinates for panning. */
-    setPanStart,
     /** Function to set the horizontal offset for panning. */
     setOffsetX,
     /** Function to set the vertical offset for panning. */

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -174,7 +174,7 @@ export const usePhotoEditor = ({
   // Effect to apply transformations and filters whenever relevant state changes.
   useEffect(() => {
     applyFilter();
-  }, [rotate, brightness, contrast, saturate, grayscale]);
+  }, [brightness, contrast, saturate, grayscale]);
 
   const redrawDrawingPaths = () => {
     const context = canvasRef.current?.getContext('2d');

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -149,6 +149,16 @@ export const usePhotoEditor = ({
       // Redraw image and drawing paths with current transformations
       context.drawImage(imgRef.current, 0, 0);
       redrawDrawingPaths();
+
+      context.beginPath();
+      context.fillStyle = '#00ff00';
+      context.arc(0,0,10,0,2*Math.PI);
+      context.fill();
+
+      context.beginPath();
+      context.fillStyle = '#ff0000';
+      context.arc(canvasRef.current.width / 2,canvasRef.current.height / 2,10,0,2*Math.PI);
+      context.fill();
     }
   }, [imageSrc]);
 
@@ -499,8 +509,18 @@ export const usePhotoEditor = ({
     const context = canvasRef.current?.getContext('2d');
     if (context == null) return;
 
+    const angle = (rotate * Math.PI) / 180;
+    const centerX = (canvasRef.current?.width ?? 0) / 2;
+    const centerY = (canvasRef.current?.height ?? 0) / 2;
+
+    context.translate(centerX, centerY);
+    context.rotate(-angle)
+    context.translate(-centerX, -centerY);
     context.translate(canvasRef.current?.width ?? 0, 0);
     context.scale(-1, 1);
+    context.translate(centerX, centerY);
+    context.rotate(angle)
+    context.translate(-centerX, -centerY);
     reDraw();
   };
 
@@ -513,8 +533,18 @@ export const usePhotoEditor = ({
     const context = canvasRef.current?.getContext('2d');
     if (context == null) return;
 
+    const angle = (rotate * Math.PI) / 180;
+    const centerX = (canvasRef.current?.width ?? 0) / 2;
+    const centerY = (canvasRef.current?.height ?? 0) / 2;
+
+    context.translate(centerX, centerY);
+    context.rotate(-angle)
+    context.translate(-centerX, -centerY);
     context.translate(0, canvasRef.current?.height ?? 0);
     context.scale(1, -1);
+    context.translate(centerX, centerY);
+    context.rotate(angle)
+    context.translate(-centerX, -centerY);
     reDraw();
   };
 

--- a/src/hooks/usePhotoEditor.tsx
+++ b/src/hooks/usePhotoEditor.tsx
@@ -129,25 +129,40 @@ export const usePhotoEditor = ({
   >([]);
   const pointerEvents = useRef<Array<React.PointerEvent<HTMLCanvasElement>>>([]);
   const prevPointerDiff = useRef(-1);
+  const currentOrigin = useRef({ x: 0, y: 0 });
 
   const reDraw = useCallback(() => {
     if (imageSrc && canvasRef.current != null) {
       if (contextRef.current == null) {
-        // Todo: still need to use image onload
         // Initial setup
         contextRef.current = canvasRef.current.getContext('2d');
         // Set canvas dimensions to match the image.
         canvasRef.current.width = imgRef.current.width;
         canvasRef.current.height = imgRef.current.height;
+        // draw image when ready
+        imgRef.current.onload = reDraw;
       }
 
-      contextRef.current?.save()
-      contextRef.current?.setTransform(1, 0, 0, 1, 0, 0);
+      contextRef.current?.save();
+      contextRef.current?.resetTransform();
       contextRef.current?.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+      contextRef.current?.restore();
+
+      contextRef.current?.save();
+
+      // apply rotation after everything else, then reset
+      if (rotate) {
+        const centerX = canvasRef.current.width / 2;
+        const centerY = canvasRef.current.height / 2;
+        contextRef.current?.translate(centerX, centerY);
+        contextRef.current?.rotate((rotate * Math.PI) / 180);
+        contextRef.current?.translate(-centerX, -centerY);
+      }
       contextRef.current?.drawImage(imgRef.current, 0, 0);
-      contextRef.current?.restore()
+      redrawDrawingPaths();
+      contextRef.current?.restore();
     }
-  }, [imageSrc]);
+  }, [imageSrc, rotate]);
 
   // Effect to update the image source when the file changes.
   useEffect(() => {
@@ -169,37 +184,25 @@ export const usePhotoEditor = ({
   // Effect to apply transformations and filters whenever relevant state changes.
   useEffect(() => {
     applyFilter();
-  }, [
-    file,
-    imageSrc,
-    rotate,
-    flipHorizontal,
-    flipVertical,
-    zoom,
-    brightness,
-    contrast,
-    saturate,
-    grayscale,
-    offsetX,
-    offsetY,
-  ]);
+  }, [rotate, brightness, contrast, saturate, grayscale]);
 
-  const redrawDrawingPaths = (context: CanvasRenderingContext2D) => {
+  const redrawDrawingPaths = () => {
+    if (contextRef.current == null) return
     drawingPathsRef.current.forEach(({ path, color, width }) => {
-      context.beginPath();
-      context.strokeStyle = color;
-      context.lineWidth = width;
-      context.lineCap = 'round';
-      context.lineJoin = 'round';
+      contextRef.current!.beginPath();
+      contextRef.current!.strokeStyle = color;
+      contextRef.current!.lineWidth = width;
+      contextRef.current!.lineCap = 'round';
+      contextRef.current!.lineJoin = 'round';
 
       path.forEach((point, index) => {
         if (index === 0) {
-          context.moveTo(point.x, point.y);
+          contextRef.current!.moveTo(point.x, point.y);
         } else {
-          context.lineTo(point.x, point.y);
+          contextRef.current!.lineTo(point.x, point.y);
         }
       });
-      context.stroke();
+      contextRef.current!.stroke();
     });
   };
 
@@ -207,60 +210,12 @@ export const usePhotoEditor = ({
    * Applies the selected filters and transformations to the image on the canvas.
    */
   const applyFilter = () => {
-    // if (!imageSrc) return;
-    //
-    //
-    // const canvas = canvasRef.current;
-    // const context = canvas?.getContext('2d');
-    //
-    // const imgElement = imgRef.current;
-    // imgRef.current.src = imageSrc;
-    // imgRef.current.onload = applyFilter;
-    //
-    // imgElement.onload = () => {
-    //   if (canvas && context) {
-    //     // const zoomedWidth = imgElement.width * zoom;
-    //     // const zoomedHeight = imgElement.height * zoom;
-    //     // const translateX = (imgElement.width - zoomedWidth) / 2;
-    //     // const translateY = (imgElement.height - zoomedHeight) / 2;
-    //
-    //     // Set canvas dimensions to match the image.
-    //     canvas.width = imgElement.width;
-    //     canvas.height = imgElement.height;
-    //
-    //     // Clear the canvas before drawing the updated image.
-    //     context.clearRect(0, 0, canvas.width, canvas.height);
-    //
-    //     // Apply filters and transformations.
-    //     context.filter = getFilterString();
-    //     context.save();
-    //
-    //     if (rotate) {
-    //       const centerX = canvas.width / 2;
-    //       const centerY = canvas.height / 2;
-    //       context.translate(centerX, centerY);
-    //       context.rotate((rotate * Math.PI) / 180);
-    //       context.translate(-centerX, -centerY);
-    //     }
-    //     if (flipHorizontal) {
-    //       context.translate(canvas.width, 0);
-    //       context.scale(-1, 1);
-    //     }
-    //     if (flipVertical) {
-    //       context.translate(0, canvas.height);
-    //       context.scale(1, -1);
-    //     }
-    //
-    //     // context.translate(translateX + offsetX, translateY + offsetY);
-    //     // context.scale(zoom, zoom);
-    //     context.drawImage(imgElement, 0, 0);
-    //
-    //     context.restore();
-    //
-    //     context.filter = 'none';
-    //     // redrawDrawingPaths(context);
-    //   }
-    // };
+    if (canvasRef.current != null && contextRef.current != null) {
+      // Apply filters and transformations.
+      contextRef.current.filter = getFilterString();
+      reDraw();
+      // redrawDrawingPaths(context);
+    }
   };
 
   /**
@@ -322,15 +277,56 @@ export const usePhotoEditor = ({
   /**
    * Handles the zoom-in action.
    */
-  const handleZoomIn = (value?: number) => {
-    setZoom((prevZoom) => prevZoom + (value ?? 0.1));
+  const handleZoomIn = () => {
+    handleZoom(0.1);
   };
 
   /**
    * Handles the zoom-out action.
    */
-  const handleZoomOut = (value?: number) => {
-    setZoom((prevZoom) => Math.max(prevZoom - (value ?? 0.1), 0.1));
+  const handleZoomOut = () => {
+    handleZoom(-0.1);
+  };
+
+  /**
+   * Handles the zoom buttons, wheel, and touches.
+   * @param value
+   * @param position - The pointer clientX and clientY.
+   */
+  const handleZoom = (value: number, position?: { x: number; y: number }) => {
+    if (canvasRef.current != null && contextRef.current != null) {
+      let scaleFactor = 1 + value;
+
+      if (zoom * scaleFactor < 0.1) {
+        // Prevent zooming out too much
+        scaleFactor = 1;
+      }
+      const newZoom = zoom * scaleFactor;
+      setZoom(newZoom);
+
+      let translateX;
+      let translateY;
+      if (position != null) {
+
+        const transformedPoint = getCanvasPositionFromPointer(position.x, position.y);
+
+        if (transformedPoint == null) return;
+
+        // Translate to the transformed position of the pointer
+        translateX = transformedPoint.x;
+        translateY = transformedPoint.y;
+      } else {
+        // Translate to the center of the canvas
+        translateX = canvasRef.current.width / 2;
+        translateY = canvasRef.current.height / 2;
+      }
+
+      contextRef.current.translate(translateX, translateY);
+      contextRef.current.scale(scaleFactor, scaleFactor);
+      // translate back to the current origin
+      contextRef.current.translate(-translateX, -translateY);
+      reDraw();
+    }
   };
 
   /**
@@ -344,14 +340,12 @@ export const usePhotoEditor = ({
       const canvas = canvasRef.current;
       if (!canvas) return;
 
-      const rect = canvas.getBoundingClientRect();
-      const scaleX = canvas.width / rect.width;
-      const scaleY = canvas.height / rect.height;
-      const x = (event.clientX - rect.left) * scaleX;
-      const y = (event.clientY - rect.top) * scaleY;
-      setDrawStart({ x, y });
+      const transformedPosition = getCanvasPositionFromPointer(event.clientX, event.clientY);
+      if (transformedPosition == null) return;
 
-      drawingPathsRef.current.push({ path: [{ x, y }], color: lineColor, width: lineWidth });
+      setDrawStart({ x: transformedPosition.x, y: transformedPosition.y });
+
+      drawingPathsRef.current.push({ path: [{ x: transformedPosition.x, y: transformedPosition.y }], color: lineColor, width: lineWidth });
     } else {
       setIsDragging(true);
       const initialX = event.clientX - (flipHorizontal ? -offsetX : offsetX);
@@ -364,54 +358,34 @@ export const usePhotoEditor = ({
    * Handles the pointer move event for updating the drawing path or panning the image.
    */
   const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (canvasRef.current == null || contextRef.current == null) return;
+
+
     // Find this event in the cache and update its record with this event
     const index = pointerEvents.current.findIndex(
       (cachedEv) => cachedEv.pointerId === event.pointerId
     );
     pointerEvents.current[index] = event;
-    const rect = canvasRef.current?.getBoundingClientRect();
-
-    console.log(
-      event.clientX,
-      event.clientY,
-      canvasRef.current?.offsetLeft,
-      canvasRef.current?.offsetTop,
-      rect?.left,
-      rect?.top,
-    );
-    console.log(
-      event.clientX - (canvasRef.current?.offsetLeft ?? 0),
-      event.clientY - (canvasRef.current?.offsetTop ?? 0),
-      event.clientX - (rect?.left ?? 0),
-      event.clientY - (rect?.top ?? 0),
-    );
 
     if (mode === 'draw' && drawStart) {
       // Draw
-      const canvas = canvasRef.current;
-      const context = canvas?.getContext('2d');
-      const rect = canvas?.getBoundingClientRect();
+      const transformedPosition = getCanvasPositionFromPointer(event.clientX, event.clientY);
+      if (transformedPosition == null) return;
 
-      if (!canvas || !context || !rect) return;
-
-      const scaleX = canvas.width / rect.width;
-      const scaleY = canvas.height / rect.height;
-      const x = (event.clientX - rect.left) * scaleX;
-      const y = (event.clientY - rect.top) * scaleY;
       const currentPath = drawingPathsRef.current[drawingPathsRef.current.length - 1].path;
 
-      context.strokeStyle = lineColor;
-      context.lineWidth = lineWidth;
-      context.lineCap = 'round';
-      context.lineJoin = 'round';
+      contextRef.current.strokeStyle = lineColor;
+      contextRef.current.lineWidth = lineWidth;
+      contextRef.current.lineCap = 'round';
+      contextRef.current.lineJoin = 'round';
 
-      context.beginPath();
-      context.moveTo(drawStart.x, drawStart.y);
-      context.lineTo(x, y);
-      context.stroke();
+      contextRef.current.beginPath();
+      contextRef.current.moveTo(drawStart.x, drawStart.y);
+      contextRef.current.lineTo(transformedPosition.x, transformedPosition.y);
+      contextRef.current.stroke();
 
-      setDrawStart({ x, y });
-      currentPath.push({ x, y });
+      setDrawStart({ x: transformedPosition.x, y: transformedPosition.y });
+      currentPath.push({ x: transformedPosition.x, y: transformedPosition.y });
 
       return;
     }
@@ -421,52 +395,40 @@ export const usePhotoEditor = ({
 
       if (pointerEvents.current.length === 1 && prevPanPosition.current != null) {
         // Pan
-        const offsetXDelta = event.clientX - prevPanPosition.current.x;
-        const offsetYDelta = event.clientY - prevPanPosition.current.y;
+        const offsetXDelta =
+          (event.clientX - prevPanPosition.current.x) * (flipHorizontal ? -1 : 1);
+        const offsetYDelta = (event.clientY - prevPanPosition.current.y) * (flipVertical ? -1 : 1);
 
-        console.log(`Panning: ${offsetXDelta}, ${offsetYDelta}, context: ${!!contextRef.current}`);
         contextRef.current?.translate(offsetXDelta, offsetYDelta);
         reDraw();
-        prevPanPosition.current = {x: event.clientX, y: event.clientY};
+        prevPanPosition.current = { x: event.clientX, y: event.clientY };
+        currentOrigin.current = {
+          x: currentOrigin.current.x + offsetXDelta,
+          y: currentOrigin.current.y + offsetYDelta,
+        };
       } else if (pointerEvents.current.length === 2) {
-        const rect = canvasRef.current?.getBoundingClientRect();
-
         // Pinch Zoom
         // If two pointers are down, check for pinch gestures
         // Calculate the distance between the two pointers
+
+        const betweenTwoPointers = {
+          x: (pointerEvents.current[0].clientX + pointerEvents.current[1].clientX) / 2,
+          y: (pointerEvents.current[0].clientY + pointerEvents.current[1].clientY) / 2,
+        };
+
         const curDiff = Math.max(
           Math.abs(pointerEvents.current[0].clientX - pointerEvents.current[1].clientX),
           Math.abs(pointerEvents.current[0].clientY - pointerEvents.current[1].clientY)
         );
-        const zoomOrigin = {
-          x: ((pointerEvents.current[0].clientX - (rect?.left ?? 0)) + (pointerEvents.current[1].clientX - (rect?.left ?? 0))) / 2,
-          y: ((pointerEvents.current[0].clientY - (rect?.top ?? 0)) + (pointerEvents.current[1].clientY - (rect?.top ?? 0))) / 2,
-        };
 
         if (prevPointerDiff.current > 0) {
-          let zoom = 1;
           if (curDiff > prevPointerDiff.current) {
             // The distance between the two pointers has increased
-            // handleZoomIn(Math.abs(prevPointerDiff.current - curDiff) * 0.01);
-            zoom = Math.abs(prevPointerDiff.current - curDiff) * 0.01;
+            handleZoom((curDiff - prevPointerDiff.current) * 0.01, betweenTwoPointers);
           }
           if (curDiff < prevPointerDiff.current) {
             // The distance between the two pointers has decreased
-            // handleZoomOut(Math.abs(prevPointerDiff.current - curDiff) * 0.01);
-            zoom = Math.abs(prevPointerDiff.current - curDiff) * 0.01;
-          }
-
-          // const originX = imgRef.current.width * zoom / 2;
-          // const originY = imgRef.current.height * zoom / 2;
-
-          // setOffsetX(originX - zoomOrigin.x);
-          // setOffsetY(originY - zoomOrigin.y);
-
-          const context = canvasRef.current?.getContext('2d');
-          if (context) {
-            context.translate(zoomOrigin.x, zoomOrigin.y);
-            context.scale(zoom, zoom);
-            context.translate(-zoomOrigin.x, -zoomOrigin.y);
+            handleZoom((curDiff - prevPointerDiff.current) * 0.01, betweenTwoPointers);
           }
         }
 
@@ -499,11 +461,63 @@ export const usePhotoEditor = ({
    */
   const handleWheel = (event: React.WheelEvent<HTMLCanvasElement>) => {
     if (event.deltaY < 0) {
-      handleZoomIn();
+      handleZoom(0.1, { x: event.clientX, y: event.clientY });
     } else {
-      handleZoomOut();
+      handleZoom(-0.1, { x: event.clientX, y: event.clientY });
     }
   };
+
+  /**
+   * Handles the horizontal flip action.
+   */
+  const handleFlipHorizontal = () => {
+    setFlipHorizontal((prev) => !prev);
+
+    contextRef.current?.translate(canvasRef.current?.width ?? 0, 0);
+    contextRef.current?.scale(-1, 1);
+    reDraw();
+  };
+
+  /**
+   * Handles the vertical flip action.
+   */
+  const handleFlipVertical = () => {
+    setFlipVertical((prev) => !prev);
+
+    contextRef.current?.translate(0, canvasRef.current?.height ?? 0);
+    contextRef.current?.scale(1, -1);
+    reDraw();
+  };
+
+  /**
+   * Handles the rotation of the image.
+   * @param angle - The angle in degrees to rotate the image.
+   */
+  const handleRotate = (angle: number) => {
+    if (canvasRef.current == null || contextRef.current == null) return;
+    setRotate(angle);
+  };
+
+  /**
+   * Calculates the canvas position from the pointer coordinates.
+   * @param clientX - The x-coordinate of the pointer. (event.clientX)
+   * @param clientY - The y-coordinate of the pointer. (event.clientY)
+   */
+  const getCanvasPositionFromPointer = (clientX: number, clientY: number) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+
+    const projectedX = clientX - (rect?.left ?? 0);
+    const projectedY = clientY - (rect?.top ?? 0);
+
+    const scaleX = (canvasRef.current?.width ?? 0) / (rect?.width ?? 0); // relationship bitmap vs. element for x
+    const scaleY = (canvasRef.current?.height ?? 0) / (rect?.height ?? 0); // relationship bitmap vs. element for y
+
+    const x = projectedX * scaleX; // scale mouse coordinates after they have
+    const y = projectedY * scaleY; // been adjusted to be relative to element
+
+    const inverseMatrix = contextRef.current?.getTransform().inverse();
+    return inverseMatrix?.transformPoint({ x, y });
+  }
 
   /**
    * Resets the filters and styles to its original state with the default settings.
@@ -526,7 +540,9 @@ export const usePhotoEditor = ({
     setIsDragging(false);
     setMode('pan');
     // applyFilter();
-    reDraw()
+    contextRef.current?.resetTransform();
+    currentOrigin.current = { x: 0, y: 0 };
+    reDraw();
   };
 
   // Expose the necessary state and handlers for external use.
@@ -574,11 +590,11 @@ export const usePhotoEditor = ({
     /** Function to set the grayscale level. */
     setGrayscale,
     /** Function to set the rotation angle. */
-    setRotate,
+    handleRotate,
     /** Function to set the horizontal flip state. */
-    setFlipHorizontal,
+    handleFlipHorizontal,
     /** Function to set the vertical flip state. */
-    setFlipVertical,
+    handleFlipVertical,
     /** Function to set the zoom level. */
     setZoom,
     /** Function to set the dragging state. */

--- a/src/tests/usePhotoEditor.test.tsx
+++ b/src/tests/usePhotoEditor.test.tsx
@@ -1,50 +1,74 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { usePhotoEditor } from '../hooks/usePhotoEditor'; // Adjust path as needed
-import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach, MockedObject } from 'vitest';
 
 describe('usePhotoEditor Hook', () => {
   const mockFile = new File(['(dummytest)'], 'test.png', { type: 'image/png' });
 
-  const mockCanvas = {
-    getContext: vi.fn(),
-    toBlob: vi.fn().mockImplementation((callback) => {
-      callback(new Blob(['test'], { type: 'image/png' }));
-    }),
-    width: 100,
-    height: 100,
-    getBoundingClientRect: vi.fn().mockReturnValue({
-      left: 0,
-      top: 0,
-      width: 100,
-      height: 100,
-    }),
-    toDataURL: vi.fn().mockReturnValue('data:image/png;base64,mocked-data'),
-  } as unknown as HTMLCanvasElement;
-
+  let mockContext: MockedObject<CanvasRenderingContext2D>;
+  let mockCanvas: MockedObject<HTMLCanvasElement>;
   beforeEach(() => {
     vi.clearAllMocks();
     global.URL.createObjectURL = vi.fn().mockReturnValue('mocked-url');
     global.URL.revokeObjectURL = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    // mockCanvas.getContext.mockReturnValue({
-    //   drawImage: vi.fn(),
-    //   clearRect: vi.fn(),
-    //   save: vi.fn(),
-    //   restore: vi.fn(),
-    //   translate: vi.fn(),
-    //   rotate: vi.fn(),
-    //   scale: vi.fn(),
-    //   filter: '',
-    //   beginPath: vi.fn(),
-    //   moveTo: vi.fn(),
-    //   lineTo: vi.fn(),
-    //   stroke: vi.fn(),
-    //   strokeStyle: '',
-    //   lineWidth: 2,
-    //   lineCap: 'round',
-    //   lineJoin: 'round',
-    // } as unknown);
+
+    mockContext = vi.mocked({
+      drawImage: vi.fn(),
+      clearRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      scale: vi.fn(),
+      filter: '',
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeStyle: '',
+      lineWidth: 2,
+      lineCap: 'round',
+      lineJoin: 'round',
+      resetTransform: vi.fn(),
+      getTransform: vi.fn().mockReturnValue({
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        is2D: true,
+        inverse: vi.fn().mockReturnValue({
+          a: 1,
+          b: 0,
+          c: 0,
+          d: 1,
+          e: 0,
+          f: 0,
+          transformPoint: vi.fn().mockReturnValue({
+            x: 0,
+            y: 0,
+          }),
+        } as unknown as DOMMatrix),
+      } as unknown as DOMMatrix),
+    } as unknown as CanvasRenderingContext2D);
+
+    mockCanvas = vi.mocked({
+      getContext: vi.fn().mockReturnValue(mockContext),
+      toBlob: vi.fn().mockImplementation((callback) => {
+        callback(new Blob(['test'], { type: 'image/png' }));
+      }),
+      width: 100,
+      height: 100,
+      getBoundingClientRect: vi.fn().mockReturnValue({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+      }),
+      toDataURL: vi.fn().mockReturnValue('data:image/png;base64,mocked-data'),
+    } as unknown as HTMLCanvasElement);
   });
 
   afterEach(() => {
@@ -151,7 +175,11 @@ describe('usePhotoEditor Hook', () => {
     const { result } = renderHook(() => usePhotoEditor({}));
 
     act(() => {
-      result.current.setRotate(45);
+      result.current.canvasRef.current = mockCanvas;
+    });
+
+    act(() => {
+      result.current.handleRotate(45);
     });
 
     expect(result.current.rotate).toBe(45);
@@ -161,7 +189,7 @@ describe('usePhotoEditor Hook', () => {
     const { result } = renderHook(() => usePhotoEditor({}));
 
     act(() => {
-      result.current.setFlipHorizontal(true);
+      result.current.handleFlipHorizontal();
     });
 
     expect(result.current.flipHorizontal).toBe(true);
@@ -171,7 +199,7 @@ describe('usePhotoEditor Hook', () => {
     const { result } = renderHook(() => usePhotoEditor({}));
 
     act(() => {
-      result.current.setFlipVertical(true);
+      result.current.handleFlipVertical();
     });
 
     expect(result.current.flipVertical).toBe(true);
@@ -191,6 +219,10 @@ describe('usePhotoEditor Hook', () => {
     const { result } = renderHook(() => usePhotoEditor({}));
 
     act(() => {
+      result.current.canvasRef.current = mockCanvas;
+    });
+
+    act(() => {
       result.current.handleZoomIn();
     });
 
@@ -199,6 +231,10 @@ describe('usePhotoEditor Hook', () => {
 
   it('should handle zoom out', () => {
     const { result } = renderHook(() => usePhotoEditor({}));
+
+    act(() => {
+      result.current.canvasRef.current = mockCanvas;
+    });
 
     act(() => {
       result.current.handleZoomOut();
@@ -288,6 +324,10 @@ describe('usePhotoEditor Hook', () => {
   it('should handle wheel zoom in', () => {
     const { result } = renderHook(() => usePhotoEditor({ file: mockFile }));
     act(() => {
+      result.current.canvasRef.current = mockCanvas;
+    });
+
+    act(() => {
       result.current.handleWheel({ deltaY: -10 } as React.WheelEvent<HTMLCanvasElement>);
     });
     expect(result.current.zoom).toBe(1.1);
@@ -295,6 +335,10 @@ describe('usePhotoEditor Hook', () => {
 
   it('should handle wheel zoom out', () => {
     const { result } = renderHook(() => usePhotoEditor({ file: mockFile }));
+    act(() => {
+      result.current.canvasRef.current = mockCanvas;
+    });
+
     act(() => {
       result.current.handleWheel({ deltaY: 10 } as React.WheelEvent<HTMLCanvasElement>);
     });
@@ -325,35 +369,13 @@ describe('usePhotoEditor Hook', () => {
     });
 
     act(() => {
-      result.current.handlePointerUp();
+      result.current.handlePointerUp({ pointerId: 1 } as React.PointerEvent<HTMLCanvasElement>);
     });
 
     expect(result.current.isDragging).toBe(false);
   });
   it('should handle pointer move for drawing', () => {
     const { result } = renderHook(() => usePhotoEditor({ file: mockFile, defaultMode: 'draw' }));
-
-    // Create a more complete mock canvas
-    const mockCanvas = {
-      width: 100,
-      height: 100,
-      getBoundingClientRect: vi.fn().mockReturnValue({
-        left: 0,
-        top: 0,
-        width: 100,
-        height: 100,
-      }),
-      getContext: vi.fn().mockReturnValue({
-        beginPath: vi.fn(),
-        moveTo: vi.fn(),
-        lineTo: vi.fn(),
-        stroke: vi.fn(),
-        strokeStyle: '',
-        lineWidth: 2,
-        lineCap: 'round',
-        lineJoin: 'round',
-      }),
-    } as unknown as HTMLCanvasElement;
 
     act(() => {
       result.current.canvasRef.current = mockCanvas;
@@ -405,8 +427,7 @@ describe('usePhotoEditor Hook', () => {
       } as unknown as React.PointerEvent<HTMLCanvasElement>);
     });
 
-    expect(result.current.offsetX).toBe(10);
-    expect(result.current.offsetY).toBe(10);
+    expect(mockContext.translate).toHaveBeenCalled();
   });
 
   it('should handle pointer move when not dragging or drawing', () => {
@@ -482,19 +503,23 @@ describe('usePhotoEditor Hook', () => {
   });
 
   it('should handle zoom with minimum limit', () => {
-    const { result } = renderHook(() => usePhotoEditor({ defaultZoom: 0.2 }));
+    const { result } = renderHook(() => usePhotoEditor({ defaultZoom: 0.12 }));
+
+    act(() => {
+      result.current.canvasRef.current = mockCanvas;
+    });
 
     act(() => {
       result.current.handleZoomOut();
     });
 
-    expect(result.current.zoom).toBe(0.1);
+    expect(result.current.zoom).toBe(0.108);
 
     act(() => {
       result.current.handleZoomOut();
     });
 
-    expect(result.current.zoom).toBe(0.1); // Shouldn't go below 0.1
+    expect(result.current.zoom).toBe(0.108); // Shouldn't go below 0.1
   });
 
   it('should generate edited file with correct mime type for jpg', async () => {


### PR DESCRIPTION
#282 

### Notable Changes

- Handle transformations as they happen instead of reacting to state changes in a single function.
- Flip, rotate around center of image
- Draw paths will respect transformations
- Replaced some `setState` returned functions with `handle` functions
- Zoom does not scale by 10% of base, instead it now applies a 10% scale to the current scale
- Supports pinch zoom
- Will zoom based on position of mouse cursor or center of pinch